### PR TITLE
[TRADUÇÃO] Documentação em inglês está, agora, em português

### DIFF
--- a/.github/us.md
+++ b/.github/us.md
@@ -1,18 +1,18 @@
-# US X - Issue Title
+# US X - Título da issue
 ---
-### Description:
-Short and useful issue's description.
+### Descrição:
+Descrição útil e curta sobre a issue.
 
-### Acceptance criteria
-Acceptance criteria for the issue being accepted.
-- [ ] Unit Tests passing
-- [ ] Something else
-- [ ] No creativity here
+### Critérios de aceitação
+Critérios de aceitação para a issue ser considerada fechada.
+- [ ] Testes passando
+- [ ] Algo a mais
+- [ ] Coisas relevantes para o fechamento da issue
 
 
 ### Tasks
-Section for more complex issues. All the tasks the issue must guarantee is working.
-- [ ] Login is redirecting to last page
-- [ ] Developers are getting coffee constantly
-- [ ] Login page has _forgot password_ link
-- [ ] No animals mistreated
+Seção para issues mais complexas. Todas as tarefas que devem estar funcionando no fim da issue:
+- [ ] Login está redirecionando para o fim da página
+- [ ] Devs estão satisfeitos com o café
+- [ ] Página de login possui botão _esqueci minha senha_
+- [ ] Nenhum animal foi ferido

--- a/README.md
+++ b/README.md
@@ -1,90 +1,88 @@
 
 
-# Project Title
+# Reabilitação Motora
 
-<p align="justify"> This work proposes the development of a platform for capturing and estimating movements capable not only of monitoring the exercises performed during a session of physiotherapy but also of evaluating them automatically, delivering quantitative and numerical results to the physiotherapist or to other applications that use a unit of processing of this system. 
+<p align="justify"> Este trabalho propõe o desenvolvimento de uma plataforma de captura, monitoramento e avaliação de movimentos realizados em sessões de fisioterapia. Os dados coletados são fornecidos ao fisioterapeuta ou a qualquer outra aplicação capaz de operar o produto em questão.
 </p>
 
-## Getting Started
+## Guia inicial
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+_Estas são instruções de como configurar o ambiente de testes e desenvolvimento na máquina do leitor_
 
-### Prerequisites
+### Pré-requisitos
 
-What things you need to install the software and how to install them
-
-```
-Give examples
-```
-
-### Installing
-
-A step by step series of examples that tell you have to get a development env running
-
-Say what the step will be
+_O que o leitor precisa para instalar o software_
 
 ```
-Give the example
+Escreva exemplos aqui
 ```
 
-And repeat
+### Instalação
+
+_Um passo a passo do que deve ser feito para rodar o ambiente de desenvolvimento_
+
+_Dê um exemplo de passo_
 
 ```
-until finished
+Escreva o exemplo
 ```
 
-End with an example of getting some data out of the system or using it for a little demo
-
-## Running the tests
-
-Explain how to run the automated tests for this system
-
-### Break down into end to end tests
-
-Explain what these tests test and why
+_E repita_
 
 ```
-Give an example
+Escreva o exemplo seguinte, até o fim do processo.
 ```
 
-### And coding style tests
+_Finalize com um exemplo de uso do sofware. Colete dados ou realize uma pequena demonstração._
 
-Explain what these tests test and why
+## Rodando os testes
+
+_Explique como funcionam os testes automatizados para esta plataforma_
+
+### Especifique cada tipo de teste
+
+_Explique o que está sendo testado e o porquê_
 
 ```
-Give an example
+Dê um exemplo.
 ```
 
-## Deployment
+### Especifique os testes que validam a folha de estilo
 
-Add additional notes about how to deploy this on a live system
+_Explique o que estes testes fazem e o porquê_
 
-## Built With
+```
+Dê um exemplo.
+```
 
-* [Dropwizard](http://www.dropwizard.io/1.0.2/docs/) - The web framework used
-* [Maven](https://maven.apache.org/) - Dependency Management
-* [ROME](https://rometools.github.io/rome/) - Used to generate RSS Feeds
+## Intalação em ambiente de produção
 
-## Contributing
+_Adicione anotações sobre como subir o ambiente de produção_
 
-Please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c63ec426) for details on our code of conduct, and the process for submitting pull requests to us.
+## Dependências
 
-## Versioning
+* [Dropwizard](http://www.dropwizard.io/1.0.2/docs/) - _O framework utilizado_
+* [Maven](https://maven.apache.org/) - _O gerenciador de dependências_
+* [ROME](https://rometools.github.io/rome/) - _Plataforma usada pra gerar feed RSS_
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
+## Como contribuir para o projeto
 
-## Authors
+Para contribuir com o projeto, verifique as instruções contidas nos arquivos CONTRIBUTING.md e codeOfConduct.md, na pasta docs do repositório.
 
-* **Billie Thompson** - *Initial work* - [PurpleBooth](https://github.com/PurpleBooth)
+## Versionamento
 
-See also the list of [contributors](https://github.com/your/project/contributors) who participated in this project.
+Todo o versionamento do projeto é realizado neste repositório, tanto da documentação quanto do código. Sinta-se livre para contribuir com ambos.
 
-## License
+## Authores
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+_Listar autores e disponibilizar link para a lista de contribuidores (docs/CONTRIBUTORS.md)_
 
-## Acknowledgments
+## Licença
 
-* Hat tip to anyone who's code was used
-* Inspiration
-* etc
+_Sinalizar a licença do projeto e disponibilizar link para o LICENSE.md_
+
+## Considerações
+
+* _Menção aos autores cujos códigos foram usados_
+* _Inspirações_
+* _etc_

--- a/docs/doxygen/documentation_and_examples.md
+++ b/docs/doxygen/documentation_and_examples.md
@@ -1,78 +1,77 @@
 <p align="justify"> &emsp;&emsp; </p>
 
-## Comment blocks for C-like languages (C/C++/C#/Objective-C/PHP/Java)
+## Blocos de comentários para linguagens C-like (C/C++/C#/Objective-C/PHP/Java)
 
-<p align="justify"> &emsp;&emsp;For each entity in the code there are two (or in some cases three) types of descriptions, which together form the documentation for that entity; a brief description and detailed description, both are optional. For methods and functions there is also a third type of description, the so called in body description, which consists of the concatenation of all comment blocks found within the body of the method or function.</p>
+<p align="justify"> &emsp;&emsp;Para cada entidade no código, existem dois (ou três, em alguns casos) tipos de descrição que, juntas, formam a documentação para aquela entidade:  uma breve descrição e uma descrição detalhada, ambas opcionais. Para métodos e funções também existe um terceiro tipo, que consiste na concatenação de todos os blocos de comentário encontrados entro do corpo do método ou da função.</p>
 
-<p align="justify"> &emsp;&emsp;Having more than one brief or detailed description is allowed (but not recommended, as the order in which the descriptions will appear is not specified).</p>
+<p align="justify"> &emsp;&emsp;Ter mais de uma breve descrição ou descrição detalhada é permitido mas não recomendado, pois a ordem na qual as descrições vão ser dispostas não é especificada.</p>
 
-<p align="justify"> &emsp;&emsp;As the name suggest, a brief description is a short one-liner, whereas the detailed description provides longer, more detailed documentation. An "in body" description can also act as a detailed description or can describe a collection of implementation details. For the HTML output brief descriptions are also used to provide tooltips at places where an item is referenced.</p>
+<p align="justify"> &emsp;&emsp;Como o nome sugere, uma descrição breve deve ser curta, preferencialmente não excedendo uma linha, já que a descrição detalhada vai fornecer documentação mais detalhada. Uma descrição dentro do corpo do método ou função também pode ter características de uma descrição detalhada ou descrever um detalhe de implementação. No output HTML, breves descrições também são usadas para prover informações onde o item é referenciado.</p>
 
-#### There are several ways to mark a comment block as a detailed description:
+#### Existem diversos modos de marcar um comentário como uma descrição detalhada, mas vamos mostrar apenas um:
 
-* You can use the JavaDoc style, which consist of a C-style comment block starting with two *'s, like this:
+* Você pode usar o estilo JavaDoc, que consiste em um bloco de comentário C-style começando com dois asteriscos, como:
 ``` C++
 /**
- * ... text ...
+ * ... texto ...
  */
 ```
 
-#### For the brief description there are also several possibilities:
+#### Para a descrição breve, existem várias possibilidades:
 
-<p align="justify"> &emsp;&emsp;One could use the @brief command with one of the above comment blocks. This command ends at the end of a paragraph, so the detailed description follows after an empty line.</p>
+<p align="justify"> &emsp;&emsp;É possível usar o comando @brief com a possibilidade acima. Este comando termina com o fim do parágrafo, então a descrição detalhada segue após uma linha em branco.</p>
 
-Here is an example:
+Por exemplo:
 ```C++
-/** @brief Brief description.
- *         Brief description continued.
+/** @brief Breve descrição.
+ *         Breve descrição continua.
  *
- *  Detailed description starts here.
+ *  Descrição detalhada começa aqui.
  */
 ```
-If JAVADOC_AUTOBRIEF is set to YES in the configuration file, then using JavaDoc style comment blocks will automatically start a brief description which ends at the first dot followed by a space or new line. Here is an example:
+Se JAVADOC_AUTOBRIEF é setada para YES nos arquivos de configuração, então usar o estilo de comentário de bloco JavaDoc irá iniciar automaticamente uma breve descrição que termina no primeiro ponto final seguido de um espaço ou quebra de linha. Exemplo:
 
 ```C++
-/** Brief description which ends at this dot. Details follow
- *  here.
+/** Breve descrição começa aqui e termina aqui. Descrição detalhada começa aqui
+ *  e continua aqui.
  */
 ```
 
-
-Here is the same piece of code as shown above, this time documented using the JavaDoc style and JAVADOC_AUTOBRIEF set to YES:
+Aqui está o mesmo trecho de código mostrado acima, mas, dessa vez, documentado utilizando o estilo JavaDoc e com JAVADOC_AUTOBRIEF setado para YES:
 ```C++
 /**
- *  A test class. A more elaborate class description.
+ *  Uma classe de testes. Uma descrição mais elaborada da classe de testes.
  */
 class Javadoc_Test
 {
   public:
     /**
-     * An enum.
-     * More detailed enum description.
+     * Um enum.
+     * Mais detalhes sobre o enum.
      */
     enum TEnum {
-          TVal1, /**< enum value TVal1. */
-          TVal2, /**< enum value TVal2. */
-          TVal3  /**< enum value TVal3. */
+          TVal1, /**< valor TVal1. do enum */
+          TVal2, /**< valor TVal2. do enum */
+          TVal3  /**< valor TVal3. do enum */
          }
-       *enumPtr, /**< enum pointer. Details. */
-       enumVar;  /**< enum variable. Details. */
+       *enumPtr, /**< Ponteiro do enum. Detalhes. */
+       enumVar;  /**< Variável enum. Detalhes. */
 
       /**
-       * A constructor.
-       * A more elaborate description of the constructor.
+       * Um construtor.
+       * Uma desrição mais elaborada do construtor.
        */
       Javadoc_Test();
       /**
-       * A destructor.
-       * A more elaborate description of the destructor.
+       * Um destrutor.
+       * Uma descrição mais elaborada do destrutor.
        */
      ~Javadoc_Test();
 
       /**
-       * a normal member taking two arguments and returning an integer value.
-       * @param a an integer argument.
-       * @param s a constant character pointer.
+       * Um membro normal pegando dois argumentos e retornando um valor inteiro.
+       * @param a, um argumento int.
+       * @param s, um ponteiro para const char.
        * @see Javadoc_Test()
        * @see ~Javadoc_Test()
        * @see testMeToo()
@@ -82,122 +81,126 @@ class Javadoc_Test
        int testMe(int a,const char *s);
 
       /**
-       * A pure virtual member.
+       * Um membro virtual puro.
        * @see testMe()
-       * @param c1 the first argument.
-       * @param c2 the second argument.
+       * @param c1, o primeiro argumento.
+       * @param c2, o segundo argumento.
        */
        virtual void testMeToo(char c1,char c2) = 0;
 
       /**
-       * a public variable.
-       * Details.
+       * Uma variável pública.
+       * Detalhes.
        */
        int publicVar;
 
       /**
-       * a function variable.
-       * Details.
+       * Uma variável de função.
+       * Detalhes.
        */
        int (*handler)(int a,int b);
 };
 ```
 
-#### Documentation at other places
+#### Documentação em outros lugares
 
-<p align="justify"> &emsp;&emsp;In the examples in the previous section the comment blocks were always located in front of the declaration or definition of a file, class or namespace or in front or after one of its members. Although this is often comfortable, there may sometimes be reasons to put the documentation somewhere else. For documenting a file this is even required since there is no such thing as "in front of a file".</p>
+<p align="justify"> &emsp;&emsp;Nos exemplos da seção anterior, os blocos de comentário estavam sempre localizados na frente da declaração ou da definição de um arquivo, classe ou namespace ou na frente de um de seus membros. Entretanto, isso pode causar desconforto, já que há vezes em que há razões para se colocar a documentação em outro lugar. Para documentar um arquivos, isto é um requerimento, já que não existe como colocar um comentário "na frente de um arquivo".</p>
 
-<p align="justify"> &emsp;&emsp;Doxygen allows you to put your documentation blocks practically anywhere (the exception is inside the body of a function or inside a normal C style comment block).</p>
+<p align="justify"> &emsp;&emsp;O Doxygen permite com que seja possível colocar seus blocos de documentação praticamente em qualquer lugar (a exceção é: dentro dos corpos das funções ou dentro de um bloco de comentário C-like).</p>
 
-<p align="justify"> &emsp;&emsp;The price you pay for not putting the documentation block directly before (or after) an item is the need to put a structural command inside the documentation block, which leads to some duplication of information. So in practice you should avoid the use of structural commands unless other requirements force you to do so.</p>
+<p align="justify"> &emsp;&emsp;O preço que você paga por não colocar o bloco de documentação diretamente antes (ou depois) de um item é a necessidade de colocar um comando estrutural dentro do bloco de documentação, o que levaria a redundância de informação. Então, na prática, você deve evitar utilizar comandos estruturais a não ser que forças maiores exijam que isso seja feito.</p>
 
-<p align="justify"> &emsp;&emsp;Structural commands (like all other commands) start with a backslash (\), or an at-sign (@) if you prefer JavaDoc style, followed by a command name and one or more parameters. For instance, if you want to document the class Test in the example above, you could have also put the following documentation block somewhere in the input that is read by doxygen:</p>
+<p align="justify"> &emsp;&emsp;Comandos estruturais, tais como todos os outros comandos, começam com "\" ou "@", se você preferir o estilo JavaDoc, seguido do nome do comando e de um ou mais parâmetros. Por exemplo, se você deseja documentar a classe Test no exemplo acima, é possível inserir o bloco de documentação em qualquer outro lugar, desde que este sirva de input para ser lido pelo Doxygen:</p>
 
 ```C++
 /** @class Test
- *  @brief A test class.
+ *  @brief Uma classe de testes.
  *
- *  A more detailed class description.
+ *  Descrição mais detalhada sobre a classe.
  */
 ```
-<p align="justify"> &emsp;&emsp;Here the special command \class is used to indicate that the comment block contains documentation for the class Test. Other structural commands are:</p>
+<p align="justify"> &emsp;&emsp;Aqui, o comando especial \class é usado para indicar que o bloco de comentário contém documentação para a classe Test. Outros comandos estuturais são:</p>
 
-* **@struct** to document a C-struct.
-* **@union** to document a union.
-* **@enum** to document an enumeration type.
-* **@fn** to document a function.
-* **@var** to document a variable or typedef or enum value.
-* **@def** to document a #define.
-* **@typedef** to document a type definition.
-* **@file** to document a file.
-* **@namespace** to document a namespace.
-* **@package** to document a Java package.
-* **@interface** to document an IDL interface.
+* **@struct** para documentar uma struct C.
+* **@union** para documentar uma union.
+* **@enum** para documentar uma implementação enum.
+* **@fn** para documentar uma função.
+* **@var** para documentar uma variável ou typedef ou valor de enum.
+* **@def** para documentar um #define.
+* **@typedef** para documentar um typedef.
+* **@file** para documentar um arquivo.
+* **@namespace** para documentar um namespace.
+* **@package** para documentar um pacote java.
+* **@interface** para documentar uma interface IDL.
 
-<p align="justify"> &emsp;&emsp;See section Special Commands for detailed information about these and many other commands.</p>
+<p align="justify"> &emsp;&emsp;Veja a seção de Special Commands do Doxygen para mais informações sobre esses e outros comandos.</p>
 
-<p align="justify"> &emsp;&emsp;To document a member of a C++ class, you must also document the class itself. The same holds for namespaces. To document a global C function, typedef, enum or preprocessor definition you must first document the file that contains it (usually this will be a header file, because that file contains the information that is exported to other source files).</p>
+<p align="justify"> &emsp;&emsp;Para documentar um membro de uma classe C++, você deve também documentar a classe inteira. O mesmo ocorre com namespaces. Para documentar uma função global do C, typedef, enum ou definição de preprocessor, você deve primeiro documentar o arquivo que a contém (normalmente isso será o header file, já que este é o arquivo que contém toda a informação que é exportada para outros arquivos fonte).</p>
 
-#### Attention
+
+#### Atenção
 
 <p align="justify"> &emsp;&emsp;Let's repeat that, because it is often overlooked: to document global objects (functions, typedefs, enum, macros, etc), you must document the file in which they are defined. In other words, there must at least be a</p>
+
+<p align="justify"> &emsp;&emsp; Vamos repetir isso, já que é comumente mal lido: para documentar um objeto global (funções, typedefs, enum, macros, etc), você deve documentar o arquivo no qual ele está definido. Em outras palavras, deve haver pelo menos um</p>
 
 ```C++
 /** @file */
 ```
 
-line in this file.
+no arquivo.
 
-<p align="justify"> &emsp;&emsp;Here is an example of a C header named structcmd.h that is documented using structural commands:</p>
+<p align="justify"> &emsp;&emsp;Segue um exemplo de um header em C nomeado structcmd.h que é documentado pelo uso de comandos estruturais:</p>
+
 
 ```C++
 
 /** @file structcmd.h
- *  @brief A Documented file.
+ *  @brief Um arquivo documentado.
  *
- *  Details.
+ *  Detalhes.
  */
 
 /** @def MAX(a,b)
- *  @brief A macro that returns the maximum of \a a and \a b.
+ *  @brief Uma macro que retorna o valor máximo de  "a" e "b".
  *
- *  Details.
+ *  Detalhes.
  */
 
 /** @var typedef unsigned int UINT32
- *  @brief A type definition for a .
+ *  @brief Uma breve descrição de "a" .
  *
  *  Details.
  */
 
 /** @var int errno
- *  @brief Contains the last error code.
- *  @warning Not thread safe!
+ *  @brief Contém o último código de erro.
+ *  @warning Não é seguro usar com threads!
  */
 
 /** @fn int open(const char *pathname,int flags)
- *  @brief Opens a file descriptor.
- *  @param pathname The name of the descriptor.
- *  @param flags Opening flags.
+ *  @brief Abre um arquivo.
+ *  @param pathname Nome/caminho do arquivo.
+ *  @param flags Flags de abertura.
  */
 
 /** @fn int close(int fd)
- *  @brief Closes the file descriptor \a fd.
- *  @param fd The descriptor to close.
+ *  @brief Fecha o arquivo e encerra sua leitura.
+ *  @param fd referência ao arquivo que deve ser fechado.
  */
 
 /** @fn size_t write(int fd,const char *buf, size_t count)
- *  @brief Writes \a count bytes from \a buf to the filedescriptor \a fd.
- *  @param fd The descriptor to write to.
- *  @param buf The data buffer to write.
- *  @param count The number of bytes to write.
+ *  @brief escreve "count" bytes de um buffer "buf" em um arquivo referenciado por "fd".
+ *  @param fd Qual arquivo que será modificado.
+ *  @param buf Buffer de dados a ser escrito.
+ *  @param count Número de bytes a ser coletado do buffer e escrito no arquivo.
  */
 
 /** @fn int read(int fd,char *buf,size_t count)
- *  @brief Read bytes from a file descriptor.
- *  @param fd The descriptor to read from.
- *  @param buf The buffer to read into.
- *  @param count The number of bytes to read.
+ *  @brief Lê bytes de um arquivo.
+ *  @param fd Referência do arquivo a ser lido.
+ *  @param buf Buffer a ser usado para manter os dados.
+ *  @param count Número de bytes a serem lidos.
  */
 #define MAX(a,b) (((a)>(b))?(a):(b))
 typedef unsigned int UINT32;
@@ -208,13 +211,17 @@ size_t write(int,const char *, size_t);
 int read(int,char *,size_t);
 ```
 
-<p align="justify"> &emsp;&emsp;When you place a comment block in a file with one of the following extensions .dox, .txt, or .doc then doxygen will hide this file from the file list.</p>
+<p align="justify"> &emsp;&emsp;Quando você coloca um bloco de comentário em um arquivo com uma das seguinte extensões: .dox, .txt ou .doc, o Doxygen irá remover este arquivo da lista de arquivos.</p>
+
 
 <p align="justify"> &emsp;&emsp;If you have a file that doxygen cannot parse but still would like to document it, you can show it as-is using \verbinclude, e.g.</p>
 
+<p align="justify"> &emsp;&emsp;Se você possui arquivos que o Doxygen não consegue identificar mas, mesmo assim, deseja documentá-lo, você pode mostrá-lo com o comando \verbinclude, por exemplo:</p>
+
+
 ```C++
 /** @file myscript.sh
- *  Look at this nice script:
+ *  Olhe este script interessante:
  *  @verbinclude myscript.sh
  */
 ```

--- a/docs/doxygen/installation_and_running.md
+++ b/docs/doxygen/installation_and_running.md
@@ -1,4 +1,4 @@
-# Installation
+# Instalação
 
 ### Doxygen
 ```
@@ -6,21 +6,21 @@ sudo apt-get install doxygen
 ```
 
 ### Doxygen GUI
-* This is a visual doxygen.
+* Versão visual do Doxygen.
 ```
 sudo apt-get install doxygen-gui
 ```
 
-# Running
+# Rodando
 
-### Generate the index file.
-* Inside the mindscape folder run:
+### Gere o arquivo index.
+* Dentro da pasta do projeto, execute:
 ```
 doxygen Doxyfile
 ```
 
-### Output folder.
-* To open the Documentation run the root above.
+### Pasta de saída.
+* Para abrir a documentação, abra o arquivo index.
 ```
 ../doxygen/html/index.html
 ```

--- a/docs/policies/PULL_REQUEST_TEMPLATE.md
+++ b/docs/policies/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,22 @@
 
-US X - Issue title
+US X - Nome da issue
 
-## Description - _<what this pull request does?>_
-Short description of all changes and its reasons.
-This section can be written using files changes.
+## Descrição - _<para que serve este pull request?>_
+Curta explicação sobre o que foi mudado e o porquê.
+Esta seção pode ser escrita usando as modificações dos arquivos.
 
-[Reference for the US/UC](#)
+[Link para a/o US/UC](#)
 
-## Why is this pull request necessary?
-Explain why it is necessary, for example:
-_It allows a developer to get fresh coffee every morning._
+## Qual a necessidade deste pull request?
+Explique o porquê deste pull request, por exemplo:
+_Permite que os desenvolvedores possam tomar um café quente todas as manhãs._
 
-## Criterias
+## Critérios de aceitação
 
 Ex:
-- [x] Created tests
-- [x] Tests passing
-- [x] Building
-- [x] No conflicts with master
+- [x] Testes criados
+- [x] Testes passando
+- [x] A etapa de _build_ está funcionando
+- [x] Não há conflitos a serem resolvidos
 
-resolves #IssueNumber
+resolve #NumeroDaIssue

--- a/docs/policies/branches.md
+++ b/docs/policies/branches.md
@@ -1,27 +1,26 @@
-# Branches creation
+# Criação de branches
 
-
-* To create a branch, the following model must be applied:
+* Para criar uma branch, o seguinte modelo deve ser aplicado:
 ```
-TagIfExists-BranchName
-```
-
-* Branch with no TAG:
-```
-BranchName
+TagSeExistir-NomeDaBranch
 ```
 
-* All spaces in **TAG** must be filled with **"_"**:
+* Branch sem tag TAG:
 ```
-Issue_Number-BranchName
-```
-
-* Branch name must not have spaces:
-```
-Issue_Number-BranchName
+NomeDaBranch
 ```
 
-### Practical Example:
+* Todos os espaços na **TAG** devem ser **"_"**:
 ```
-Issue_64-FixPhysicsLateUpdate
+Numero_da_issue-NomeDaBranch
+```
+
+* Os nomes das branches não deves ter espaços:
+```
+Numero_da_issue-NomeDaBranch
+```
+
+### Exemplo prático:
+```
+Issue_64-CorrigePhysicsLateUpdate
 ```

--- a/docs/policies/commits.md
+++ b/docs/policies/commits.md
@@ -1,11 +1,11 @@
-# Commits Policy
+# Política de commits
 
-* Commits must use the following model:
+* Os commits devem utilizar o seguinte modelo:
 ```
-[TAG] Brief description
+[TAG] Breve descrição
 ```
 
-* Practical Example:
+* Exemplo prático:
 ```
-[BUG] Recover input movement
+[BUG] Corrige captura de movimento
 ```

--- a/docs/policies/style_sheet.md
+++ b/docs/policies/style_sheet.md
@@ -15,49 +15,49 @@ Data|Versão|Descrição|Autor
 
 -----
 
-## 1. Naming
+## 1. Nomes
 
-**1.1.** Use **CamelCase** to name attributes and parameters.
+**1.1.** Use **CamelCase** para dar nome a atributos e parâmetros.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     string studentName;
 
 
-    // Bad example
+    // Mau exemplo
     string student_name;
 
 ```
 
-**1.2.** Use **PascalCase** to name methods.
+**1.2.** Use **PascalCase** para dar nome a métodos.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void SetGameObject(int studentName)
     {
         this.studentName = studentName;
     }
 
-    // Bad example
+    // Mau exemplo
     void setgameObject(int studentname)
     {
         this.student_name = studentname;
     }
 ```
 
-**1.3.** Every method name must express verbally what it does.
+**1.3.** Os nomes dos métodos devem bem representar o que é realizado.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void RegisterGameObject(GameObject player)
     {
           print(player.name);
     }
 
-    // Bad example
+    // Mau exemplo
     void game_object_registration(GameObject player)
     {
           print(player.name);
@@ -65,88 +65,88 @@ Data|Versão|Descrição|Autor
 
 ```
 
-**1.4.** Use **PascalCase** to name classes and interfaces.
+**1.4.** Use **PascalCase** para dar nome a classes e interfaces.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     public class PlayerMovement
     {
       /*...*/
     }
 
-    // Bad example
+    // Mau exemplo
     public class playermovement
     {
         /*...*/
     }
 ```
 
-**1.5.** Use significative names on attributes. Abbreviations must not be used.
+**1.5.** Use nomes significativos em atributos. Abreviações NÃO devem ser usadas.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     Vector3 playerVelocity;
 
-    // Bad example
+    // Mau exemplo
     Vector3 pv;
 
 ```
 
-**1.6.**  There must not be attributes named with a single character, like `a`, `b`, `c`. The only exception is `i` on loops.
+**1.6.**  Não deve existir variáveis nomeadas com letras únicas, como `a`, `b`, `c`. A única exceção é o uso de `i` em estruturas de repetição (loop).
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     Rigidbody rigidbody = GetComponent<Rigidbody>();
 
-    // Bad example
+    // Mau exemplo
     Rigidbody r = GetComponent<Rigidbody>();
 
 ```
 
-**1.7.** Constants must be written on SCREAMING_SNAKE_CASE.
+**1.7.** Constantes devem ser escritas no padrão SCREAMING_SNAKE_CASE.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     public const int MINIMUM_PASSWORD_HEIGHT = 6;
 
-    // Bad example
+    // Mau exemplo
     public const int MINIMUMPASSWORDHEIGHT = 6;
 
 ```
 
-**1.8.** Treat acronyms as words.
+**1.8.** Trate acrônimos como palavras.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     string urlPost = "https://google/api/save";
 
-    // Bad example
+    // Mau exemplo
     string URLPost = "https://google/api/save";
 
 ```
 
-**[[Back to top|Style-Sheet]]**
+**[[Voltar ao topo|Style-Sheet]]**
 
 -----
-## 2. Formatting
+## 2. Formatação
 
-**2.1.** Use TABs to indent.
+**2.1.** Use TABs para indentar.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     bool GetPlayerVelocity()
     {
         Rigidbody rigidBody = GetComponent<Rigidbody>();
         return rigidBody.velocity;
     }
 
-    // Bad example
+    // Mau exemplo
     bool GetPlayerVelocity()
     {
     Rigidbody rigidBody = GetComponent<Rigidbody>();
@@ -154,11 +154,11 @@ Data|Versão|Descrição|Autor
     }
 ```
 
-**2.2.** Skip a line to separate logical groups.
+**2.2.** Pule uma linha para separar blocos lógicos.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     public float moveSpeed = 10f;
     public float turnSpeed = 50f;
 
@@ -167,7 +167,7 @@ Data|Versão|Descrição|Autor
       transform.Translate(Vector3.forward * moveSpeed * Time.deltaTime);
     }
 
-    // Bad example
+    // Mau exemplo
     public float moveSpeed = 10f;
     public float turnSpeed = 50f;
     if(transform.position.x > 0.0f)
@@ -177,11 +177,11 @@ Data|Versão|Descrição|Autor
 
 ```
 
-**2.3.** Single line expressions must not have more than 80 characters.
+**2.3.** Cada linha não deve apresentar mais do que 80 caracteres.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void RegisterGameObject(GameObject player)
     {
       print("omg im so happy that im going to write a giant
@@ -189,7 +189,7 @@ Data|Versão|Descrição|Autor
       i registered a player object!!!");
     }
 
-    // Bad example
+    // Mau exemplo
     void RegisterGameObject(GameObject player)
     {
       print("omg im so happy that im going to write a giant bible here check this out guys omg i cant believe that i registered a player object!!!");
@@ -198,28 +198,28 @@ Data|Versão|Descrição|Autor
 
 ```
 
-**2.4.** Always skip a line to open a bracket that belongs to a method, loop or conditional structure. The closing bracket must have the same indentation level as its own structure.
+**2.4.** Sempre pule uma linha para abrir o escopo de um método, estrutura de repetição ou estrutura condicional. A chave que fecha o escopo deve ter a mesma indentação daquela que o abriu.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void MovePlayer ()
     {
       transform.Translate(Vector3.forward * 5f * Time.deltaTime);
     }
 
-    // Bad example
+    // Mau exemplo
     void MovePlayer () {
       transform.Translate(Vector3.forward * 5f * Time.deltaTime);
     }
 
 ```
 
-**2.5.** There must be a space between operators.
+**2.5.** Deve haver espaços entre os operadores.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void Update ()
     {
       float h = Input.GetAxis("Horizontal");
@@ -229,7 +229,7 @@ Data|Versão|Descrição|Autor
       textOutput.text = "Value Returned: " + h.ToString("F2");
     }
 
-    // Bad example
+    // Mau exemplo
     void Update ()
     {
       float h=Input.GetAxis("Horizontal");
@@ -241,11 +241,11 @@ Data|Versão|Descrição|Autor
 
 ```
 
-**2.6.** There must not be any space after `(`, `[` and before `)`, `]`, **except** after funtions declarations.
+**2.6.** Não deve haver espaço após `(`, `[` e antes de `)`, `]`, **exceto** após declarações de métodos.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void Update ()
     {
         if(Input.GetKey(KeyCode.Space))
@@ -254,7 +254,7 @@ Data|Versão|Descrição|Autor
         }
     }
 
-    // Bad example
+    // Mau exemplo
     void Update ()
     {
         if( Input.GetKey ( KeyCode.Space ) )
@@ -265,11 +265,11 @@ Data|Versão|Descrição|Autor
 
 ```
 
-**2.7.** In loops. there must not be a line after `}`.
+**2.7.** Em estruturas de repetição, Não deve haver quebra de linha após fechar o escopo com `}`.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     for (i = 0; i < players.size(); i++)
     {
         for (int j = 0; j < players.size() - 1; j++)
@@ -281,7 +281,7 @@ Data|Versão|Descrição|Autor
 	      }
     }
 
-    // Bad example
+    // Mau exemplo
     for (i = 0; i < players.size(); i++)
     {
         for (int j = 0; j < players.size() - 1; j++)
@@ -295,11 +295,11 @@ Data|Versão|Descrição|Autor
 
     }
 ```
-**2.8.** There must not be a space after a method name, `for`, `if`, `else if` and `switch`.
+**2.8.** Não deve haver espaço após `for`, `if`, `else if` e `switch`.
 
 ``` csharp
 
-    // Good example
+    // Bom exemplo
     void TemperatureTest ()
     {
         if(coffeeTemperature > hotLimitTemperature)
@@ -316,7 +316,7 @@ Data|Versão|Descrição|Autor
         }
     }
 
-    // Bad example
+    // Mau exemplo
     void TemperatureTest ()
     {
         if (coffeeTemperature > hotLimitTemperature)
@@ -337,4 +337,4 @@ Data|Versão|Descrição|Autor
 ```
 
 
-**[[Back to top|Style-Sheet]]**
+**[[Voltar ao topo|Style-Sheet]]**


### PR DESCRIPTION
#5  - Tradução Commits, Branch e Style Sheet Wiki

## Os documentos devem estar, todos, em português.
A documentação já existente possuía textos em inglês, que foram devidamente traduzidos.
Por exemplo:
![image](https://user-images.githubusercontent.com/26290053/37209158-e8f99eb2-2382-11e8-99c2-8f325c2d1534.png)


[Tradução Commits, Branch e Style Sheet Wiki](https://github.com/fga-gpp-mds/2018.1-Reabilitacao-Motora/issues/5)

## Qual a necessidade deste pull request?
Com os documentos em português, padronizamos o uso da língua nativa da maioria dos alunos da UnB.

## Critérios de aceitação

Ex:
- [x] Não existir documentação em inglês na pasta docs

resolve #5 