### PR TITLE
Corrigindo bug de Paciente Cadastrado no Menu de Ajuda de Criar Novo Paciente

### DIFF
--- a/Reabilitacao-Motora/Assets/Scenes/HelpExercise.unity
+++ b/Reabilitacao-Motora/Assets/Scenes/HelpExercise.unity
@@ -1172,8 +1172,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 139, y: -17}
-  m_SizeDelta: {x: 200, y: 30}
+  m_AnchoredPosition: {x: 186.9, y: -17}
+  m_SizeDelta: {x: 300, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &922436503
 MonoBehaviour:

--- a/Reabilitacao-Motora/Assets/Scenes/HelpPatient.unity
+++ b/Reabilitacao-Motora/Assets/Scenes/HelpPatient.unity
@@ -1274,7 +1274,6 @@ GameObject:
   - component: {fileID: 1292820162}
   - component: {fileID: 1292820161}
   - component: {fileID: 1292820160}
-  - component: {fileID: 1292820159}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -1282,19 +1281,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1292820159
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1292820158}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c602af96f2c4e8f4997138a920f47b45, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  buttonPrefab: {fileID: 1768867090189390, guid: 5b9a1c1db73b6f346bb53e55afb797e2,
-    type: 2}
 --- !u!114 &1292820160
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Tutorial de criação de novos pacientes desformatado

## Descrição 
Há um bug no menu de ajuda de criação de Paciente onde um paciente do programa estava também cadastrado na scene de ajuda.

[Issue 212](#212 )

## Porque este Pull Request é necessário?
Corrigido o bug no menu de ajuda de criação de paciente. Foi devidamente removido o paciente e suas informações na tela 

## Critérios

Ex:
- [x] Tutorial sem sobreposição de layouts
- [x] Build passando
- [x] Testes passando
- [x] Analisar causa do bug
- [x] Corrigir bug

Resolve #212 


![](https://thumbs.gfycat.com/GargantuanSpectacularChinesecrocodilelizard-size_restricted.gif) 
