### PR TITLE
Redimensionando e alinhando botões na scene de escolher sensor

### DIFF
--- a/Reabilitacao-Motora/Assets/Scenes/ChoiceSensor.unity
+++ b/Reabilitacao-Motora/Assets/Scenes/ChoiceSensor.unity
@@ -480,11 +480,11 @@ RectTransform:
   m_Father: {fileID: 1624486615}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -20, y: 10}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 10, y: 102}
   m_SizeDelta: {x: 100, y: 30}
-  m_Pivot: {x: 1, y: 0}
+  m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &424782931
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -637,19 +637,19 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
-    m_Font: {fileID: 12800000, guid: 8a8b4184e9c3b4047881a39d17fa1db2, type: 3}
+    m_Font: {fileID: 12800000, guid: 6bbad337ba6f03b4abeaffdf79e7e069, type: 3}
     m_FontSize: 16
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 1
     m_MaxSize: 40
-    m_Alignment: 3
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Kinect
+  m_Text: KINECT
 --- !u!222 &476040099
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -765,11 +765,11 @@ RectTransform:
   m_Father: {fileID: 1624486615}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 75, y: 0}
-  m_SizeDelta: {x: 200, y: 40}
-  m_Pivot: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &790931320
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -814,9 +814,9 @@ MonoBehaviour:
   m_Value: 0
   m_Options:
     m_Options:
-    - m_Text: Kinect
+    - m_Text: KINECT
       m_Image: {fileID: 0}
-    - m_Text: Sensor UDP
+    - m_Text: SENSOR UDP
       m_Image: {fileID: 0}
   m_OnValueChanged:
     m_PersistentCalls:
@@ -1225,8 +1225,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 5, y: -5}
-  m_SizeDelta: {x: 50, y: 25}
+  m_AnchoredPosition: {x: 10, y: -1}
+  m_SizeDelta: {x: 90, y: 40}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1371992082
 MonoBehaviour:
@@ -1427,9 +1427,9 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 40, y: -5}
+  m_AnchoredPosition: {x: 133, y: -23}
   m_SizeDelta: {x: 160, y: 30}
-  m_Pivot: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1480393201
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Descrição 
Redimensiona o tamanho de alguns botões e os alinha de acordo com a scene.
[Tamanho dos botões da scene de configuração](#272)

## Porque este Pull Request é necessário?
Para uma melhor experiência ao usuario, manter um padrão entre os botões e textos na scene.

## Critérios
- [x] Build passando

Resolve #272 .