### PR TITLE
Exibição de resultados (Personagens) 

### DIFF
--- a/Reabilitacao-Motora/Assets/Scenes/Graphs1.unity
+++ b/Reabilitacao-Motora/Assets/Scenes/Graphs1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -162,15 +162,15 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 400004, guid: 0ed08faf6b2c64f13ae389013c74d2d7, type: 3}
       propertyPath: m_LocalScale.x
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400004, guid: 0ed08faf6b2c64f13ae389013c74d2d7, type: 3}
       propertyPath: m_LocalScale.y
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400004, guid: 0ed08faf6b2c64f13ae389013c74d2d7, type: 3}
       propertyPath: m_LocalScale.z
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 400004, guid: 0ed08faf6b2c64f13ae389013c74d2d7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x


### PR DESCRIPTION
### Descrição:
Corrige o bug da exibição de resultados dos exercícios as imagens dos bonecos do kinect estão desformatadas, desalinhadas e não condizentes. As vezes os bonecos que eram para serem iguais são diferentes as vezes estão em tamanhos desproporcionais.
![resultado do movimento](https://user-images.githubusercontent.com/18054053/41324425-ccd8a91e-6e8a-11e8-952d-13247e0e604f.png)


### Critérios de Aceitação
Critérios de aceitação para a Issue ser aceita.
- [x] Testes Unit passando (PlayTests).
- [x] Tela refatorada e arrumada.


### Tarefas
Seção para tarefas de Issues mais complexas. As tarefas devem garantir o perfeito funcionamento da Issue.
- [x] Arrumar formatação dos bonecos

Resolve #304 .

![](https://media.giphy.com/media/FahhzR9aHCgjC/giphy.gif)