### PR TITLE
Persistencia da escolha do tipo de sensor

### DIFF
--- a/Reabilitacao-Motora/Assets/Scripts/Instantiations/Movement/createMovement.cs
+++ b/Reabilitacao-Motora/Assets/Scripts/Instantiations/Movement/createMovement.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using UnityEngine.UI;
@@ -69,6 +70,35 @@ public class createMovement : MonoBehaviour
 			}
 
 			GlobalController.patientOrPhysio = true;
+
+			
+			// Checks the sensor choice from the file
+
+			StringBuilder sensorPath = new StringBuilder();
+			sensorPath.Append("sensor.choice");
+        
+        	string choicePath = sensorPath.ToString();
+
+			if (File.Exists(choicePath)) // User has already chosen a sensor
+        	{
+				string line = File.ReadAllText(choicePath);
+				int fileValue = Convert.ToInt32(line);
+				
+				if ( fileValue.Equals(0) ) // Kinect selected
+				{
+					GlobalController.Sensor = false;
+				}
+				else if ( fileValue.Equals(1) ) // UDP selected
+				{
+					GlobalController.Sensor = true;
+				}
+        	}
+			else // Kinect is default value
+			{
+				GlobalController.Sensor = false;
+			}
+
+			// Redirects user to correct scene
 
 			if(GlobalController.Sensor == false)
 			{

--- a/Reabilitacao-Motora/Assets/SensorChoice.cs
+++ b/Reabilitacao-Motora/Assets/SensorChoice.cs
@@ -1,12 +1,64 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
+using UnityEngine.UI;
+using System.IO;
+using System;
 
 public class SensorChoice : MonoBehaviour {
 
+    Dropdown m_Dropdown;
+    string choicePath;
+
+    void Start()
+    {
+        m_Dropdown = GetComponent<Dropdown>();
+
+        StringBuilder path = new StringBuilder();
+			path.Append("sensor.choice");
+        
+        choicePath = path.ToString();
+
+        if (File.Exists(choicePath))
+        {
+            
+            string line = File.ReadAllText(choicePath);
+            int fileValue = Convert.ToInt32(line);
+            
+            if ( fileValue.Equals(0) )
+            {
+                m_Dropdown.value = 0;
+                GlobalController.Sensor = false;
+            }
+            else if ( fileValue.Equals(1) )
+            {
+                m_Dropdown.value = 1;
+                GlobalController.Sensor = true;
+            }
+        }
+        else 
+        {
+            string text = Convert.ToString(m_Dropdown.value);
+            File.WriteAllText(choicePath, text);
+        }
+    }
+
     public void Select()
     {
-        GlobalController.Sensor = !GlobalController.Sensor;
+
+        if ( m_Dropdown.value.Equals(0) ) // Kinect selected
+        {
+            GlobalController.Sensor = false;
+        }
+        else // UDP selected
+        {
+            GlobalController.Sensor = true;
+        }
+
+        string text = Convert.ToString(m_Dropdown.value);
+        File.Delete(choicePath);
+        File.WriteAllText(choicePath, text);
     }
 
 }

--- a/Reabilitacao-Motora/ProjectSettings/ProjectSettings.asset
+++ b/Reabilitacao-Motora/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 13
+  serializedVersion: 14
   productGUID: b80daf7c4acc34abea32b0bc4fff8f2b
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -61,6 +61,7 @@ PlayerSettings:
   allowedAutorotateToLandscapeLeft: 1
   useOSAutorotation: 1
   use32BitDisplayBuffer: 1
+  preserveFramebufferAlpha: 0
   disableDepthAndStencilBuffers: 0
   androidBlitType: 0
   defaultIsFullScreen: 1
@@ -91,7 +92,6 @@ PlayerSettings:
   allowFullscreenSwitch: 1
   graphicsJobMode: 0
   macFullscreenMode: 2
-  d3d9FullscreenMode: 1
   d3d11FullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
@@ -101,7 +101,6 @@ PlayerSettings:
   n3dsDisableStereoscopicView: 0
   n3dsEnableSharedListOpt: 1
   n3dsEnableVSync: 0
-  ignoreAlphaClear: 0
   xboxOneResolution: 0
   xboxOneSResolution: 0
   xboxOneXResolution: 3
@@ -130,6 +129,7 @@ PlayerSettings:
   bundleVersion: 1.0
   preloadedAssets: []
   metroInputSource: 0
+  wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 0
   xboxOneEnable7thCore: 0
@@ -142,8 +142,14 @@ PlayerSettings:
       useSustainedPerformanceMode: 0
       enableVideoLayer: 0
       useProtectedVideoMemory: 0
+      minimumSupportedHeadTracking: 0
+      maximumSupportedHeadTracking: 1
     hololens:
       depthFormat: 1
+      depthBufferSharingEnabled: 0
+    oculus:
+      sharedDepthBuffer: 0
+      dashSupport: 0
   protectGraphicsMemory: 0
   useHDRDisplay: 0
   m_ColorGamuts: 00000000
@@ -219,6 +225,8 @@ PlayerSettings:
   iOSLaunchScreeniPadFillPct: 100
   iOSLaunchScreeniPadSize: 100
   iOSLaunchScreeniPadCustomXibPath: 
+  iOSUseLaunchScreenStoryboard: 0
+  iOSLaunchScreenCustomStoryboardPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
   iOSBackgroundModes: 0
@@ -230,6 +238,7 @@ PlayerSettings:
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
   appleEnableAutomaticSigning: 0
+  clonedFromGUID: 00000000000000000000000000000000
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -258,6 +267,13 @@ PlayerSettings:
     Android: 1
     iPhone: 1
     tvOS: 1
+  m_BuildTargetGroupLightmapEncodingQuality:
+  - m_BuildTarget: Standalone
+    m_EncodingQuality: 1
+  - m_BuildTarget: XboxOne
+    m_EncodingQuality: 1
+  - m_BuildTarget: PS4
+    m_EncodingQuality: 1
   wiiUTitleID: 0005000011000000
   wiiUGroupID: 00010000
   wiiUCommonSaveSize: 4096
@@ -426,6 +442,8 @@ PlayerSettings:
   ps4PronunciationSIGPath: 
   ps4BackgroundImagePath: 
   ps4StartupImagePath: 
+  ps4StartupImagesFolder: 
+  ps4IconImagesFolder: 
   ps4SaveDataImagePath: 
   ps4SdkOverride: 
   ps4BGMPath: 
@@ -591,12 +609,6 @@ PlayerSettings:
   n3dsTitle: GameName
   n3dsProductCode: 
   n3dsApplicationId: 0xFF3FF
-  stvDeviceAddress: 
-  stvProductDescription: 
-  stvProductAuthor: 
-  stvProductAuthorEmail: 
-  stvProductLink: 
-  stvProductCategory: 0
   XboxOneProductId: 
   XboxOneUpdateKey: 
   XboxOneSandboxId: 


### PR DESCRIPTION
# Persistencia da escolha do tipo de sensor

## Descrição
A tela de configuração do sensor agora consegue persistir a escolha do usuário mesmo quando a aplicação é encerrada.

[Persistencia da escolha do tipo de sensor](#298)

## Porque este Pull Request é necessário?
Melhora o UX ao: 
- Deixar a opção do usuário sempre atualizada no dropdown da página de configuração.
- Persistir a seleção do usuário para evitar a reconfiguração a cada sessão de uso.

## Critérios

Ex:
- [x] Testes passando.
- [x] Build passando
- [x] Sem conflitos com a Branch Development

Resolve #298.


![](https://media.giphy.com/media/3o6ZtpvPW6fqxkE1xu/giphy.gif) 
