### PR TITLE
Arrumando bug do UDP

### DIFF
--- a/Reabilitacao-Motora/Assets/Scripts/Graphs/MoveByUDP.cs
+++ b/Reabilitacao-Motora/Assets/Scripts/Graphs/MoveByUDP.cs
@@ -31,7 +31,6 @@ public class MoveByUDP : MonoBehaviour
 
     UdpClient client;
     public int receivePort = 5004;
-    IPAddress groupIP = IPAddress.Parse("127.0.0.1");
     IPEndPoint remoteEP;   
 
     string rxString;
@@ -90,7 +89,6 @@ public class MoveByUDP : MonoBehaviour
         remoteEP = new IPEndPoint(IPAddress.Any, receivePort);
 
         client = new UdpClient(remoteEP);
-        client.JoinMulticastGroup(groupIP);
 
         client.BeginReceive(new AsyncCallback(ReceiveServerInfo), null);
     	
@@ -238,4 +236,10 @@ public class MoveByUDP : MonoBehaviour
 			}
 		}
 	}
+
+    void OnApplicationQuit()
+    {
+        client.Close();
+    }
+
 }


### PR DESCRIPTION
## Descrição
O MoveByUdp teve alterações para uma conexão mais estavel entre cliente e servidor.

[Bug com UDP](#339)

## Porque este Pull Request é necessário?
O UDP pode ser inicializado quantas vezes for necessário sem erro de socket.

## Critérios
- [x] Testes passando.
- [x] Build passando
- [x] UDP com um ótimo fuincionamento.

Resolve #339 .